### PR TITLE
Upgrade from 'node16' to 'node20'

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ branding:
   icon: "check-square"
   color: "green"
 runs:
-  using: "node16"
+  using: "node20"
   pre: "dist/pre/index.js"
   main: "dist/index.js"
   post: "dist/post/index.js"


### PR DESCRIPTION
Upgrade the Node.js version used to run this action from Node.js v16 ('node16') to Node.js v20 ('node20'). For more information see: <https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/>.

This follows warnings that started to show up in GitHub Actions summary annotations like:

```log
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

(Where eb238b55efaa70779f274895e782ed17c84f2895 is <https://github.com/step-security/harden-runner/releases/tag/v2.6.1>.)