### PR TITLE
Update actions/upload-artifact in Scorecards from v3.0.0 to v4.6.1

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -54,7 +54,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # tag=v3.0.0
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # tag=v4.6.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Prompted by https://github.com/MariaDB4j/MariaDB4j/issues/1107,

due to https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.