### PR TITLE
docs: document api-key fallback behavior

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
     required: false
     default: ""
   api-key:
-    description: "StepSecurity API key for authenticating with the policy store. Required when use-policy-store is set to true."
+    description: "StepSecurity API key for authenticating with the policy store. If omitted when use-policy-store is true, Harden-Runner defaults to audit mode."
     required: false
     default: ""
   use-policy-store:


### PR DESCRIPTION
## Summary

Update the `api-key` action input description to document its current fallback behavior.

## Motivation

Since #665, enabling `use-policy-store` without an API key no longer fails the action. Harden-Runner emits a warning and defaults to audit mode, but `action.yml` still says the key is required.

## Changes

- Document the audit-mode fallback in the `api-key` input description.
- Keep runtime behavior unchanged.

## Validation

- `git diff --check`
- `npm test -- --runInBand` (67 tests passed)
- `npm run build` (passed; no `dist/` changes)
- Parsed `action.yml` as YAML and checked the updated description
- `npm run lint` reports 80 existing errors in unchanged `src/` files
