### PR TITLE
fix: correct stale version comments on five SHA-pinned actions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -22,14 +22,14 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v1
+    - uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
       with:
         egress-policy: audit
         allowed-endpoints:
           api.github.com:443
           github.com:443
 
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - name: Update the rc tag
       uses: step-security/publish-action@b438f840875fdcb7d1de4fc3d1d30e86cf6acb5d
       with:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -30,12 +30,12 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v3.0.0
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # tag=v1.1.1
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # tag=v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -62,6 +62,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@2d790406f505036ef40ecba973cc774a50395aac # tag=v1.0.26
+        uses: github/codeql-action/upload-sarif@2d790406f505036ef40ecba973cc774a50395aac # tag=v3.25.13
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
### What

Five SHA-pinned actions carry a version comment naming a release that the pinned commit does not have. The SHAs are unchanged — only the comments are corrected to match the tag each commit actually carries.

| File | Action | Pinned SHA | Comment said | Actually is |
|---|---|---|---|---|
| `canary.yml:25` | `step-security/harden-runner` | `5c7944e7` | `v1` | **v2.9.1** |
| `canary.yml:32` | `actions/checkout` | `b4ffde65` | `v2` | **v4.1.1** |
| `scorecards.yml:33` | `actions/checkout` | `b4ffde65` | `tag=v3.0.0` | **v4.1.1** |
| `scorecards.yml:38` | `ossf/scorecard-action` | `62b2cac7` | `tag=v1.1.1` | **v2.4.0** |
| `scorecards.yml:65` | `github/codeql-action` | `2d790406` | `tag=v1.0.26` | **v3.25.13** |

### Why

The comment is the only human-readable signal of which release a pin refers to — nothing validates it, so it drifts silently when a SHA is bumped and the comment isn't. Here it understates by one or two major versions, which is the direction that causes real confusion: a reader auditing `canary.yml` sees `harden-runner # v1` and reasonably concludes the workflow is a major version behind, when it is actually on v2.9.1.

This repo already contains the correct labels for two of these SHAs — `test.yml:22` and `dependency-review.yml:20` label `5c7944e7` as `v2.9.1`, and `test.yml:35` labels `b4ffde65` as `v4.1.1`. So this change also makes the workflow files internally consistent with each other.

### How to verify

Each row is one API call — the tag the SHA carries versus what the tag in the comment actually points at:

```bash
# what tags does the pinned commit carry?
gh api repos/actions/checkout/tags --paginate \
  --jq '.[] | select(.commit.sha=="b4ffde65f46336ab88eb53be808477a3936bae11") | .name'
# -> v4.1.1

# and where does the claimed tag actually point?
gh api repos/actions/checkout/git/ref/tags/v2 --jq '.object.sha'
# -> 0717577d45739eb3c851188b29f50ed6c0b2194e   (a different commit)
```

Same shape for the other four. Every pinned SHA in this repo's workflows was checked; these five were the only mismatches.

### Scope

Comment-only change, so there is no behavioural difference and CI should be unaffected.

Deliberately **not** included, since they're separate decisions rather than factual errors:

- Several of these pins are genuinely old (`checkout` v4.1.1 is from Oct 2023, `codeql-action` v3.25.13 from mid-2024). Bumping them is a real change that deserves its own PR and its own test run.
- `scorecards.yml` uses the older `# tag=vX.Y.Z` comment style while the newer workflows use `# vX.Y.Z`. I kept each file's existing convention so this diff stays purely factual.

Found by comparing every pinned SHA in `.github/workflows/` against the tags that commit actually carries.
